### PR TITLE
Update acf-contact-form-settings.php

### DIFF
--- a/acf-contact-form-settings.php
+++ b/acf-contact-form-settings.php
@@ -373,9 +373,9 @@
 
 
 			function acf_load_templates( $field ) {
-				if(file_exists(get_template_directory() . '/acf-cf-templates')) {
+				if(file_exists(get_stylesheet_directory() . '/acf-cf-templates')) {
 				// reset choices
-				$files = scandir(get_template_directory() . '/acf-cf-templates');
+				$files = scandir(get_stylesheet_directory() . '/acf-cf-templates');
 
 				if(!empty($files)) {
 					foreach($files as $file) {


### PR DESCRIPTION
Changed get_template_directory to get_stylesheet_directory to make the plugin compatible with child themes.

From https://codex.wordpress.org/Function_Reference/get_template_directory :

"In the case a child theme is being used, the absolute path to the parent theme directory will be returned. Use get_stylesheet_directory() to get the absolute path to the child theme directory."
